### PR TITLE
Wrong whitelisted cmd for delete

### DIFF
--- a/frappeclient/frappeclient.py
+++ b/frappeclient/frappeclient.py
@@ -54,7 +54,7 @@ class FrappeClient(object):
 
 	def delete(self, doctype, name):
 		return self.post_request({
-			"cmd": "frappe.model.delete_doc",
+			"cmd": "frappe.client.delete",
 			"doctype": doctype,
 			"name": name
 		})


### PR DESCRIPTION
- Should use frappe.client.delete instead of frappe.model.delete_doc (which is not whitelisted)