### PR TITLE
Add unittests, cleanup setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ logply/config.py
 /dist
 _build/
 MANIFEST
+env/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.DS_STORE
 *.swp
 *.egg-info
+*.ropeproject
 logply/config.py
 /dist
 _build/

--- a/frappeclient/frappeclient_tests.py
+++ b/frappeclient/frappeclient_tests.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from frappeclient import FrappeClient
+import urlparse
+import httpretty
+import unittest
+
+
+class FrappeClientTest(unittest.TestCase):
+
+    @httpretty.activate
+    def setUp(self):
+        httpretty.register_uri(httpretty.POST,
+                               "http://example.com",
+                               body='{"message":"Logged In"}',
+                               content_type="application/json"
+                               )
+        self.frappe = FrappeClient("http://example.com",
+                                   "user@example.com",
+                                   "password")
+
+    @httpretty.activate
+    def test_get_doc_with_no_doc_name(self):
+        httpretty.register_uri(
+            httpretty.GET,
+            "http://example.com/api/resource/SomeDoc/",
+            body='{"data": { "f1": "v1","f2": "v2"}}',
+            content_type="application/json"
+        )
+        res = self.frappe.get_doc(
+            "SomeDoc",
+            filters=[["Note", "title", "LIKE", "S%"]],
+            fields=["name", "foo"])
+
+        self.assertEquals(res, {'f1': 'v1', 'f2': 'v2'})
+
+        request = httpretty.last_request()
+        url = urlparse.urlparse(request.path)
+        query_dict = urlparse.parse_qs(url.query)
+        self.assertEquals(query_dict['fields'],
+                          [u'["name", "foo"]'])
+        self.assertEquals(query_dict['filters'],
+                          [u'[["Note", "title", "LIKE", "S%"]]'])

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,20 @@
-from distutils.core import setup
-import os
+from setuptools import setup
 
 version = '0.1.0dev'
 
+with open('requirements.txt') as requirements:
+    install_requires = requirements.read().split()
+
 setup(
-    name='FrappeClient',
+    name='frappeclient',
     version=version,
     author='Rushabh Mehta',
     author_email='rmehta@erpnext.com',
-    download_url='https://github.com/jevonearth/frappe-client/archive/'+version+'.tar.gz',
-    packages=['frappeclient',],
-    install_requires=open(os.path.join(os.path.dirname(__file__), 'requirements.txt')).read().split(),
+    packages=[
+        'frappeclient'
+    ],
+    install_requires=install_requires,
+    tests_requires=[
+        'httmock<=1.2.2'
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     ],
     install_requires=install_requires,
     tests_requires=[
-        'httmock<=1.2.2'
+        'httmock<=1.2.2',
+        'nose<=1.3.4'
     ],
 )


### PR DESCRIPTION
Add tests that uses unittest, and HTTPretty. 
Switch to setuptools, so we can get tests_requires.
PEP-8 updates
Remove download link, as it was wrong, and it is not needed for pip installs from git. Can be put back in if/when this package gets published to pypi.
Changes package namein setup.py from FrappeClient to frappeclient (PEP-8)