### PR TITLE
Few fixes to make library python3 compatible. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 logply/config.py
 /dist
 _build/
+build/
 MANIFEST
 env/

--- a/frappeclient/frappeclient.py
+++ b/frappeclient/frappeclient.py
@@ -117,8 +117,7 @@ class FrappeClient(object):
 			"name": name
 		})
 
-	def get_doc(self, doctype, name="", filters=None, fields=None):
-		params = {}
+	def get_doc(self, doctype, name="", filters=None, fields=None, params={}):
 		if filters:
 			params["filters"] = json.dumps(filters)
 		if fields:

--- a/frappeclient/frappeclient.py
+++ b/frappeclient/frappeclient.py
@@ -1,6 +1,23 @@
-import requests
+import sys
 import json
-from StringIO import StringIO
+import requests
+
+# thin compatibility support for python3
+if sys.version_info[0] < 3: # py2
+    from StringIO import StringIO
+    #python 2
+    def itervalues(d):
+        return d.itervalues()
+    def iteritems(d):
+        return d.iteritems()
+
+else: # py3
+    from io import StringIO
+    #python 3
+    def itervalues(d):
+        return iter(d.values())
+    def iteritems(d):
+        return iter(d.items())
 
 class AuthError(Exception):
 	pass
@@ -104,8 +121,8 @@ class FrappeClient(object):
 		params = {}
 		if filters:
 			params["filters"] = json.dumps(filters)
-                if fields:
-                        params["fields"] = json.dumps(fields)
+		if fields:
+			params["fields"] = json.dumps(fields)
 
 		res = self.session.get(self.url + "/api/resource/" + doctype + "/" + name,
 			params=params)
@@ -192,7 +209,7 @@ class FrappeClient(object):
 
 	def preprocess(self, params):
 		"""convert dicts, lists to json"""
-		for key, value in params.iteritems():
+		for key, value in iteritems(params):
 			if isinstance(value, (dict, list)):
 				params[key] = json.dumps(value)
 
@@ -202,7 +219,7 @@ class FrappeClient(object):
 		try:
 			rjson = response.json()
 		except ValueError:
-			print response.text
+			print(response.text)
 			raise
 
 		if rjson and ("exc" in rjson) and rjson["exc"]:
@@ -225,7 +242,7 @@ class FrappeClient(object):
 			try:
 				rjson = response.json()
 			except ValueError:
-				print response.text
+				print(response.text)
 				raise
 
 			if rjson and ("exc" in rjson) and rjson["exc"]:

--- a/frappeclient/frappeclient_tests.py
+++ b/frappeclient/frappeclient_tests.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 from frappeclient import FrappeClient
-import urlparse
+try:
+    import urlparse
+except:
+    import urllib.parse as urlparse
+
 import httpretty
 import unittest
 


### PR DESCRIPTION
Included a thin compatibility layer at the head of frappeclient.py to achieve this.

Hi we are building a sync tool for our customers and internal needs. We have an in house project that needed to talk to ERPNext but was written in python3. I added very small changes to get your library to be used with python 3 and wanted to see if you would be interested in using those changes.

We would be happy to help with py3 compatibility as your project evolves.
