### PR TITLE
Python 3 fixes, get_list API added

### DIFF
--- a/frappeclient/frappeclient.py
+++ b/frappeclient/frappeclient.py
@@ -1,238 +1,258 @@
 import requests
 import json
-from StringIO import StringIO
+from io import StringIO
 
 class AuthError(Exception):
-	pass
+    pass
 
 class FrappeException(Exception):
-	pass
+    pass
 
 class NotUploadableException(FrappeException):
-	def __init__(self, doctype):
-		self.message = "The doctype `{1}` is not uploadable, so you can't download the template".format(doctype)
+    def __init__(self, doctype):
+        self.message = "The doctype `{1}` is not uploadable, so you can't download the template".format(doctype)
 
 CAN_DOWNLOAD = []
 
 class FrappeClient(object):
-	def __init__(self, url, username, password):
-		self.session = requests.Session()
-		self.url = url
-		self.login(username, password)
+    def __init__(self, url, username, password):
+        self.session = requests.Session()
+        self.url = url
+        self.login(username, password)
 
-	def __enter__(self):
-		return self
+    def __enter__(self):
+        return self
 
-	def __exit__(self, *args, **kwargs):
-		self.logout()
+    def __exit__(self, *args, **kwargs):
+        self.logout()
 
-	def login(self, username, password):
-		global CAN_DOWNLOAD
-		r = self.session.post(self.url, data={
-			'cmd': 'login',
-			'usr': username,
-			'pwd': password
-		})
+    def login(self, username, password):
+        global CAN_DOWNLOAD
+        r = self.session.post(self.url, data={
+            'cmd': 'login',
+            'usr': username,
+            'pwd': password
+        })
 
-		if r.json().get('message') == "Logged In":
-			CAN_DOWNLOAD = []
-			return r.json()
-		else:
-			raise AuthError
+        if r.json().get('message') == "Logged In":
+            CAN_DOWNLOAD = []
+            return r.json()
+        else:
+            raise AuthError
 
-	def logout(self):
-		global CAN_DOWNLOAD
-		self.session.get(self.url, params={
-			'cmd': 'logout',
-		})
-		CAN_DOWNLOAD = []
+    def logout(self):
+        global CAN_DOWNLOAD
+        self.session.get(self.url, params={
+            'cmd': 'logout',
+        })
+        CAN_DOWNLOAD = []
 
-	def insert(self, doc):
-		res = self.session.post(self.url + "/api/resource/" + doc.get("doctype"),
-			data={"data":json.dumps(doc)})
-		return self.post_process(res)
+    def insert(self, doc):
+        res = self.session.post(self.url + "/api/resource/" + doc.get("doctype"),
+            data={"data":json.dumps(doc)})
+        return self.post_process(res)
 
-	def update(self, doc):
-		url = self.url + "/api/resource/" + doc.get("doctype") + "/" + doc.get("name")
-		res = self.session.put(url, data={"data":json.dumps(doc)})
-		return self.post_process(res)
+    def update(self, doc):
+        url = self.url + "/api/resource/" + doc.get("doctype") + "/" + doc.get("name")
+        res = self.session.put(url, data={"data":json.dumps(doc)})
+        return self.post_process(res)
 
-	def bulk_update(self, docs):
-		return self.post_request({
-			"cmd": "frappe.client.bulk_update",
-			"docs": json.dumps(docs)
-		})
+    def bulk_update(self, docs):
+        return self.post_request({
+            "cmd": "frappe.client.bulk_update",
+            "docs": json.dumps(docs)
+        })
 
-	def delete(self, doctype, name):
-		return self.post_request({
-			"cmd": "frappe.client.delete",
-			"doctype": doctype,
-			"name": name
-		})
+    def delete(self, doctype, name):
+        return self.post_request({
+            "cmd": "frappe.client.delete",
+            "doctype": doctype,
+            "name": name
+        })
 
-	def submit(self, doclist):
-		return self.post_request({
-			"cmd": "frappe.client.submit",
-			"doclist": json.dumps(doclist)
-		})
+    def submit(self, doclist):
+        return self.post_request({
+            "cmd": "frappe.client.submit",
+            "doclist": json.dumps(doclist)
+        })
 
-	def get_value(self, doctype, fieldname=None, filters=None):
-		return self.get_request({
-			"cmd": "frappe.client.get_value",
-			"doctype": doctype,
-			"fieldname": fieldname or "name",
-			"filters": json.dumps(filters)
-		})
+    def get_value(self, doctype, fieldname=None, filters=None):
+        return self.get_request({
+            "cmd": "frappe.client.get_value",
+            "doctype": doctype,
+            "fieldname": fieldname or "name",
+            "filters": json.dumps(filters)
+        })
 
-	def set_value(self, doctype, docname, fieldname, value):
-		return self.post_request({
-			"cmd": "frappe.client.set_value",
-			"doctype": doctype,
-			"name": docname,
-			"fieldname": fieldname,
-			"value": value
-		})
+    def set_value(self, doctype, docname, fieldname, value):
+        return self.post_request({
+            "cmd": "frappe.client.set_value",
+            "doctype": doctype,
+            "name": docname,
+            "fieldname": fieldname,
+            "value": value
+        })
 
-	def cancel(self, doctype, name):
-		return self.post_request({
-			"cmd": "frappe.client.cancel",
-			"doctype": doctype,
-			"name": name
-		})
+    def cancel(self, doctype, name):
+        return self.post_request({
+            "cmd": "frappe.client.cancel",
+            "doctype": doctype,
+            "name": name
+        })
 
-	def get_doc(self, doctype, name="", filters=None, fields=None):
-		params = {}
-		if filters:
-			params["filters"] = json.dumps(filters)
-                if fields:
-                        params["fields"] = json.dumps(fields)
+    def get_doc(self, doctype, name="", filters=None, fields=None):
+        params = {}
+        if filters:
+            params["filters"] = json.dumps(filters)
+            if fields:
+                params["fields"] = json.dumps(fields)
 
-		res = self.session.get(self.url + "/api/resource/" + doctype + "/" + name,
-			params=params)
+        res = self.session.get(self.url + "/api/resource/" + doctype + "/" + name,
+            params=params)
 
-		return self.post_process(res)
+        return self.post_process(res)
 
-	def rename_doc(self, doctype, old_name, new_name):
-		params = {
-			"cmd": "frappe.client.rename_doc",
-			"doctype": doctype,
-			"old_name": old_name,
-			"new_name": new_name
-		}
-		return self.post_request(params)
+    def get_list(self, doctype, name="", filters=None, fields=None,
+    limit_start=None, limit_page_length=None):
+        params = {
+            "cmd": "frappe.client.get_list",
+            "doctype": doctype,
+            "filters": filters,
+            #"order_by": order_by,
+            "limit_start": limit_start,
+            "limit_page_length": limit_page_length
+        }
+        if filters:
+            params["filters"] = json.dumps(filters)
+            if fields:
+                params["fields"] = json.dumps(fields)
 
-	def get_pdf(self, doctype, name, print_format="Standard", letterhead=True):
-		params = {
-			'doctype': doctype,
-			'name': name,
-			'format': print_format,
-			'no_letterhead': int(not bool(letterhead))
-		}
-		response = self.session.get(
-			self.url + "/api/method/frappe.templates.pages.print.download_pdf",
-			params=params, stream=True)
+        res = self.session.get(self.url + "/api/resource/" + doctype + "/" + name,
+            params=params)
 
-		return self.post_process_file_stream(response)
+        return self.post_process(res)
 
-	def get_html(self, doctype, name, print_format="Standard", letterhead=True):
-		params = {
-			'doctype': doctype,
-			'name': name,
-			'format': print_format,
-			'no_letterhead': int(not bool(letterhead))
-		}
-		response = self.session.get(
-			self.url + '/print', params=params, stream=True
-		)
-		return self.post_process_file_stream(response)
+    def rename_doc(self, doctype, old_name, new_name):
+        params = {
+            "cmd": "frappe.client.rename_doc",
+            "doctype": doctype,
+            "old_name": old_name,
+            "new_name": new_name
+        }
+        return self.post_request(params)
 
-	def __load_downloadable_templates(self):
-		global CAN_DOWNLOAD
-		CAN_DOWNLOAD = self.get_api('frappe.core.page.data_import_tool.data_import_tool.get_doctypes')
+    def get_pdf(self, doctype, name, print_format="Standard", letterhead=True):
+        params = {
+            'doctype': doctype,
+            'name': name,
+            'format': print_format,
+            'no_letterhead': int(not bool(letterhead))
+        }
+        response = self.session.get(
+            self.url + "/api/method/frappe.templates.pages.print.download_pdf",
+            params=params, stream=True)
 
-	def get_upload_template(self, doctype, with_data=False):
-		global CAN_DOWNLOAD
-		if not CAN_DOWNLOAD:
-			self.__load_downloadable_templates()
+        return self.post_process_file_stream(response)
 
-		if doctype not in CAN_DOWNLOAD:
-			raise NotUploadableException(doctype)
+    def get_html(self, doctype, name, print_format="Standard", letterhead=True):
+        params = {
+            'doctype': doctype,
+            'name': name,
+            'format': print_format,
+            'no_letterhead': int(not bool(letterhead))
+        }
+        response = self.session.get(
+            self.url + '/print', params=params, stream=True
+        )
+        return self.post_process_file_stream(response)
 
-		params = {
-			'doctype': doctype,
-			'parent_doctype': doctype,
-			'with_data': 'Yes' if with_data else 'No',
-			'all_doctypes': 'Yes'
-		}
+    def __load_downloadable_templates(self):
+        global CAN_DOWNLOAD
+        CAN_DOWNLOAD = self.get_api('frappe.core.page.data_import_tool.data_import_tool.get_doctypes')
 
-		request = self.session.get(self.url +
-			'/api/method/frappe.core.page.data_import_tool.exporter.get_template',
-			params=params)
-		return self.post_process_file_stream(request)
+    def get_upload_template(self, doctype, with_data=False):
+        global CAN_DOWNLOAD
+        if not CAN_DOWNLOAD:
+            self.__load_downloadable_templates()
 
-	def get_api(self, method, params={}):
-		res = self.session.get(self.url + "/api/method/" + method + "/",
-			params=params)
-		return self.post_process(res)
+        if doctype not in CAN_DOWNLOAD:
+            raise NotUploadableException(doctype)
 
-	def post_api(self, method, params={}):
-		res = self.session.post(self.url + "/api/method/" + method + "/",
-			params=params)
-		return self.post_process(res)
+        params = {
+            'doctype': doctype,
+            'parent_doctype': doctype,
+            'with_data': 'Yes' if with_data else 'No',
+            'all_doctypes': 'Yes'
+        }
 
-	def get_request(self, params):
-		res = self.session.get(self.url, params=self.preprocess(params))
-		res = self.post_process(res)
-		return res
+        request = self.session.get(self.url +
+            '/api/method/frappe.core.page.data_import_tool.exporter.get_template',
+            params=params)
+        return self.post_process_file_stream(request)
 
-	def post_request(self, data):
-		res = self.session.post(self.url, data=self.preprocess(data))
-		res = self.post_process(res)
-		return res
+    def get_api(self, method, params={}):
+        res = self.session.get(self.url + "/api/method/" + method + "/",
+            params=params)
+        return self.post_process(res)
 
-	def preprocess(self, params):
-		"""convert dicts, lists to json"""
-		for key, value in params.iteritems():
-			if isinstance(value, (dict, list)):
-				params[key] = json.dumps(value)
+    def post_api(self, method, params={}):
+        res = self.session.post(self.url + "/api/method/" + method + "/",
+            params=params)
+        return self.post_process(res)
 
-		return params
+    def get_request(self, params):
+        res = self.session.get(self.url, params=self.preprocess(params))
+        res = self.post_process(res)
+        return res
 
-	def post_process(self, response):
-		try:
-			rjson = response.json()
-		except ValueError:
-			print response.text
-			raise
+    def post_request(self, data):
+        res = self.session.post(self.url, data=self.preprocess(data))
+        res = self.post_process(res)
+        return res
 
-		if rjson and ("exc" in rjson) and rjson["exc"]:
-			raise FrappeException(rjson["exc"])
-		if 'message' in rjson:
-			return rjson['message']
-		elif 'data' in rjson:
-			return rjson['data']
-		else:
-			return None
+    def preprocess(self, params):
+        """convert dicts, lists to json"""
+        for key, value in params.iteritems():
+            if isinstance(value, (dict, list)):
+                params[key] = json.dumps(value)
 
-	def post_process_file_stream(self, response):
-		if response.ok:
-			output = StringIO()
-			for block in response.iter_content(1024):
-				output.write(block)
-			return output
+        return params
 
-		else:
-			try:
-				rjson = response.json()
-			except ValueError:
-				print response.text
-				raise
+    def post_process(self, response):
+        try:
+            rjson = response.json()
+        except ValueError:
+            print(response.text)
+            raise
 
-			if rjson and ("exc" in rjson) and rjson["exc"]:
-				raise FrappeException(rjson["exc"])
-			if 'message' in rjson:
-				return rjson['message']
-			elif 'data' in rjson:
-				return rjson['data']
-			else:
-				return None
+        if rjson and ("exc" in rjson) and rjson["exc"]:
+            raise FrappeException(rjson["exc"])
+        if 'message' in rjson:
+            return rjson['message']
+        elif 'data' in rjson:
+            return rjson['data']
+        else:
+            return None
+
+    def post_process_file_stream(self, response):
+        if response.ok:
+            output = StringIO()
+            for block in response.iter_content(1024):
+                output.write(block)
+            return output
+
+        else:
+            try:
+                rjson = response.json()
+            except ValueError:
+                print(response.text)
+                raise
+
+            if rjson and ("exc" in rjson) and rjson["exc"]:
+                raise FrappeException(rjson["exc"])
+            if 'message' in rjson:
+                return rjson['message']
+            elif 'data' in rjson:
+                return rjson['data']
+            else:
+                return None

--- a/frappeclient/frappeclient.py
+++ b/frappeclient/frappeclient.py
@@ -118,7 +118,6 @@ class FrappeClient(object):
             "cmd": "frappe.client.get_list",
             "doctype": doctype,
             "filters": filters,
-            #"order_by": order_by,
             "limit_start": limit_start,
             "limit_page_length": limit_page_length
         }


### PR DESCRIPTION
Not an exhaustive refactoring for Python 3+, but some housekeeping
Added get_list function to match public API, "order_by" argument is not accepted, so I removed it. Not sure why. 
Qualifier: "it works on my machine" 