### PR TITLE
Token authentication fixes

### DIFF
--- a/frappeclient/frappeclient.py
+++ b/frappeclient/frappeclient.py
@@ -61,8 +61,7 @@ class FrappeClient(object):
 			raise AuthError
 
 	def authenticate(self, api_key, api_secret):
-		token = b64encode('{}:{}'.format(api_key, api_secret))
-		auth_header = {'Authorization': 'Basic {}'.format(token)}
+		auth_header = {'Authorization': 'token {}:{}'.format(api_key, api_secret)}
 		self.session.headers.update(auth_header)
 
 	def logout(self):

--- a/frappeclient/frappeclient.py
+++ b/frappeclient/frappeclient.py
@@ -247,11 +247,11 @@ class FrappeClient(object):
 		return self.post_process_file_stream(request)
 
 	def get_api(self, method, params={}):
-		res = self.session.get(self.url + '/api/method/' + method + '/', params=params)
+		res = self.session.get(self.url + '/api/method/' + method, params=params)
 		return self.post_process(res)
 
 	def post_api(self, method, params={}):
-		res = self.session.post(self.url + '/api/method/' + method + '/', params=params)
+		res = self.session.post(self.url + '/api/method/' + method, params=params)
 		return self.post_process(res)
 
 	def get_request(self, params):

--- a/frappeclient/frappeclient_tests.py
+++ b/frappeclient/frappeclient_tests.py
@@ -38,7 +38,7 @@ class TestFrappeClient(unittest.TestCase):
 	def test_token_auth(self):
 		self.conn.authenticate('test_key', 'test_secret')
 		auth_header = self.conn.session.headers.get('Authorization')
-		self.assertEquals(auth_header, 'Basic dGVzdF9rZXk6dGVzdF9zZWNyZXQ=')
+		self.assertEquals(auth_header, 'token test_key:test_secret')
 
 
 if __name__=='__main__':


### PR DESCRIPTION
In my setup two bugs were discovered in token-based authentication scenario:
- `b64encode` was causing some problems. I changed the request according to official documentation, which didn't require "Basic" authentication encoding.
- slash in API calls resulted in 301 redirect to slashless URLs, which resulted in "Authorization" header being removed.