### PR TITLE
Add token authentication success check

### DIFF
--- a/frappeclient/frappeclient.py
+++ b/frappeclient/frappeclient.py
@@ -61,10 +61,14 @@ class FrappeClient(object):
 		else:
 			raise AuthError
 
-	def authenticate(self, api_key, api_secret):
+	def authenticate(self, api_key, api_secret, test_success=False):
 		token = b64encode('{}:{}'.format(api_key, api_secret))
 		auth_header = {'Authorization': 'Basic {}'.format(token)}
 		self.session.headers.update(auth_header)
+
+		if test_success:
+			# If the authorization isn't successful AuthError is raised in post_process
+			self.get_api("frappe.auth.get_logged_user")
 
 	def logout(self):
 		self.session.get(self.url, params={

--- a/frappeclient/frappeclient.py
+++ b/frappeclient/frappeclient.py
@@ -28,12 +28,13 @@ class NotUploadableException(FrappeException):
 
 
 class FrappeClient(object):
-	def __init__(self, url=None, username=None, password=None, api_key=None, api_secret=None, verify=True):
+	def __init__(self, url=None, username=None, password=None, api_key=None, api_secret=None, verify=True, print_on_error=True):
 		self.headers = dict(Accept='application/json')
 		self.session = requests.Session()
 		self.can_download = []
 		self.verify = verify
 		self.url = url
+		self.print_on_error = print_on_error
 
 		if username and password:
 			self.login(username, password)
@@ -277,7 +278,8 @@ class FrappeClient(object):
 		try:
 			rjson = response.json()
 		except ValueError:
-			print(response.text)
+			if self.print_on_error:
+				print(response.text)
 			raise
 
 		if rjson and ('exc' in rjson) and rjson['exc']:
@@ -300,7 +302,8 @@ class FrappeClient(object):
 			try:
 				rjson = response.json()
 			except ValueError:
-				print(response.text)
+				if self.print_on_error:
+					print(response.text)
 				raise
 
 			if rjson and ('exc' in rjson) and rjson['exc']:

--- a/frappeclient/frappeclient.py
+++ b/frappeclient/frappeclient.py
@@ -27,6 +27,14 @@ class NotUploadableException(FrappeException):
 		self.message = "The doctype `{1}` is not uploadable, so you can't download the template".format(doctype)
 
 
+class DocumentNotFound(FrappeException):
+	def __init__(self, doctype="", name=""):
+		if doctype and name:
+			self.message = "Document `{0}` of doctype `{1}` not found.".format(name, doctype)
+		else:
+			self.message = "Document not found."
+
+
 class FrappeClient(object):
 	def __init__(self, url=None, username=None, password=None, api_key=None, api_secret=None, verify=True, print_on_error=True):
 		self.headers = dict(Accept='application/json')
@@ -281,6 +289,12 @@ class FrappeClient(object):
 	def post_process(self, response):
 		if response.status_code == 401:
 			raise AuthError
+		if response.status_code == 404:
+			if response.request.path_url.startswith("/api/resource/"):
+				path = response.request.path_url.split("/")
+				raise DocumentNotFound(path[3], path[4])
+			else:
+				raise DocumentNotFound
 
 		try:
 			rjson = response.json()

--- a/frappeclient/frappeclient.py
+++ b/frappeclient/frappeclient.py
@@ -275,6 +275,9 @@ class FrappeClient(object):
 		return params
 
 	def post_process(self, response):
+		if response.status_code == 401:
+			raise AuthError
+
 		try:
 			rjson = response.json()
 		except ValueError:


### PR DESCRIPTION
- add `print_on_error` argument to `FrappeClient` class to suppress potentially unwanted stdout prints.
- raise `AuthError` exception for any 401 response (for example when using token-based authentication).
- add authentication success check for token-based authentication.

Fixes #36