### PR TITLE
Fix default fields value in get_list

### DIFF
--- a/frappeclient/frappeclient.py
+++ b/frappeclient/frappeclient.py
@@ -71,7 +71,7 @@ class FrappeClient(object):
 			'cmd': 'logout',
 		})
 
-	def get_list(self, doctype, fields='"*"', filters=None, limit_start=0, limit_page_length=0, order_by=None):
+	def get_list(self, doctype, fields='["*"]', filters=None, limit_start=0, limit_page_length=0, order_by=None):
 		'''Returns list of records of a particular type'''
 		if not isinstance(fields, unicode):
 			fields = json.dumps(fields)


### PR DESCRIPTION
default value `fields="*"` will cause error: `File "/usr/lib/python3.8/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`