### PR TITLE
fix: param for frappe.client.submit

### DIFF
--- a/frappeclient/frappeclient.py
+++ b/frappeclient/frappeclient.py
@@ -141,7 +141,7 @@ class FrappeClient(object):
 		:param doc: dict or Document object to be submitted remotely'''
 		return self.post_request({
 			'cmd': 'frappe.client.submit',
-			'doclist': json.dumps(doclist)
+			'doc': json.dumps(doclist)
 		})
 
 	def get_value(self, doctype, fieldname=None, filters=None):


### PR DESCRIPTION
Error:
```
17:46:50 web.1         | Traceback (most recent call last):
17:46:50 web.1         |   File "apps/frappe/frappe/app.py", line 110, in application
17:46:50 web.1         |     frappe.handler.handle()
17:46:50 web.1         |   File "apps/frappe/frappe/handler.py", line 49, in handle
17:46:50 web.1         |     data = execute_cmd(cmd)
17:46:50 web.1         |            ^^^^^^^^^^^^^^^^
17:46:50 web.1         |   File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
17:46:50 web.1         |     return frappe.call(method, **frappe.form_dict)
17:46:50 web.1         |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:46:50 web.1         |   File "apps/frappe/frappe/__init__.py", line 1775, in call
17:46:50 web.1         |     return fn(*args, **newargs)
17:46:50 web.1         |            ^^^^^^^^^^^^^^^^^^^^
17:46:50 web.1         |   File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
17:46:50 web.1         |     return func(*args, **kwargs)
17:46:50 web.1         |            ^^^^^^^^^^^^^^^^^^^^^
17:46:50 web.1         | TypeError: submit() missing 1 required positional argument: 'doc'
```

```
Error: Failed to submit Invoice Record: Expecting value: line 1 column 1 (char 0)
```